### PR TITLE
Run btool check

### DIFF
--- a/roles/docker_image_build/defaults/main.yml
+++ b/roles/docker_image_build/defaults/main.yml
@@ -57,3 +57,7 @@ entrypoint_user: "{{ splunk_user_id }}:{{ splunk_group_id }}"
 # the provided entrypoint.sh (defined above) runs splunk
 # if install_splunk is set to false entrypoint also needs to be overridden
 install_splunk: true
+
+# set to false if you have a configuration that is known not to pass btool check,
+# but should successfully build anyway (TAs with incomplete README/ contents, etc.)
+btool_check: true

--- a/roles/docker_image_build/templates/build/Dockerfile
+++ b/roles/docker_image_build/templates/build/Dockerfile
@@ -54,6 +54,11 @@ USER {{ entrypoint_user }}
 # dump into $SPLUNK_HOME for exec, etc
 WORKDIR {{ splunk_home }}
 
+# btool check needs to succeed before moving on
+{% if install_splunk and btool_check %}
+RUN {{ splunk_home }}/bin/splunk btool check
+{% endif %}
+
 # entrypoint.sh may do run-time configurations prior to starting splunk
 ENTRYPOINT {{ entrypoint }}
 


### PR DESCRIPTION
Closes #46

This MR adds a `RUN` command to the templated `Dockerfile` to validate Splunk's configuration via `btool` before the image can be successfully built.