### PR TITLE
added general pass4SymmKey option

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ a value of `True` when the non-standalone image is built.  Thus we have these im
 * Disables indexes
 * Disables splunkweb
 * Sets license master
+* Sets pass4SymKey
 
 The set of included stage items attempts to get you on your feet with this process as soon as possible.  These are
 configurations we consider standard and reasonable for almost all instances.

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ a value of `True` when the non-standalone image is built.  Thus we have these im
 * Disables indexes
 * Disables splunkweb
 * Sets license master
-* Sets pass4SymKey
+* Sets pass4SymmKey
 
 The set of included stage items attempts to get you on your feet with this process as soon as possible.  These are
 configurations we consider standard and reasonable for almost all instances.

--- a/examples/all-in-one/inventory.yml
+++ b/examples/all-in-one/inventory.yml
@@ -30,4 +30,4 @@
               # against populated lookups to forward results to the indexing tier.  the forwarder license doesn't enable
               # this type of usage.
               license_master_uri: https://lm.example.org:8089
-              splunk_pass4SymmKey: pleasechangeme
+              pass4SymmKey: pleasechangeme

--- a/examples/all-in-one/inventory.yml
+++ b/examples/all-in-one/inventory.yml
@@ -30,4 +30,4 @@
               # against populated lookups to forward results to the indexing tier.  the forwarder license doesn't enable
               # this type of usage.
               license_master_uri: https://lm.example.org:8089
-              splunk_key: pleasechangeme
+              splunk_pass4SymmKey: pleasechangeme

--- a/examples/all-in-one/inventory.yml
+++ b/examples/all-in-one/inventory.yml
@@ -30,3 +30,4 @@
               # against populated lookups to forward results to the indexing tier.  the forwarder license doesn't enable
               # this type of usage.
               license_master_uri: https://lm.example.org:8089
+              splunk_key: pleasechangeme

--- a/examples/organized-environment/group_vars/all.yml
+++ b/examples/organized-environment/group_vars/all.yml
@@ -14,7 +14,7 @@ splunk_admin_password: pleasechangeme
 # specify a license master, but just a dummy here
 license_master_uri: https://lm.example.org:8089
 # specify a pass4SymmKey for the License Master
-splunk_pass4SymmKey: pleasechangeme
+pass4SymmKey: pleasechangeme
 
 # if you need to escalate privilege to a different user to perform docker operations, specify it here
 # docker_become_user:

--- a/examples/organized-environment/group_vars/all.yml
+++ b/examples/organized-environment/group_vars/all.yml
@@ -14,7 +14,7 @@ splunk_admin_password: pleasechangeme
 # specify a license master, but just a dummy here
 license_master_uri: https://lm.example.org:8089
 # specify a pass4SymmKey for the License Master
-splunk_key: pleasechangeme
+splunk_pass4SymmKey: pleasechangeme
 
 # if you need to escalate privilege to a different user to perform docker operations, specify it here
 # docker_become_user:

--- a/examples/organized-environment/group_vars/all.yml
+++ b/examples/organized-environment/group_vars/all.yml
@@ -13,6 +13,8 @@ splunk_admin_password: pleasechangeme
 
 # specify a license master, but just a dummy here
 license_master_uri: https://lm.example.org:8089
+# specify a pass4SymmKey for the License Master
+splunk_key: pleasechangeme
 
 # if you need to escalate privilege to a different user to perform docker operations, specify it here
 # docker_become_user:

--- a/roles/docker_image_build/templates/primary_build/etc/apps/docker_service_server_production/default/server.conf
+++ b/roles/docker_image_build/templates/primary_build/etc/apps/docker_service_server_production/default/server.conf
@@ -1,2 +1,4 @@
+pass4SymmKey = {{ splunk_key }}
+
 [license]
 master_uri = {{ license_master_uri }}

--- a/roles/docker_image_build/templates/primary_build/etc/apps/docker_service_server_production/default/server.conf
+++ b/roles/docker_image_build/templates/primary_build/etc/apps/docker_service_server_production/default/server.conf
@@ -1,4 +1,7 @@
-pass4SymmKey = {{ splunk_pass4SymmKey }}
+{% if pass4SymmKey is defined %}
+[general]
+pass4SymmKey = {{ pass4SymmKey }}
+{% endif %}
 
 [license]
 master_uri = {{ license_master_uri }}

--- a/roles/docker_image_build/templates/primary_build/etc/apps/docker_service_server_production/default/server.conf
+++ b/roles/docker_image_build/templates/primary_build/etc/apps/docker_service_server_production/default/server.conf
@@ -1,4 +1,4 @@
-pass4SymmKey = {{ splunk_key }}
+pass4SymmKey = {{ splunk_pass4SymmKey }}
 
 [license]
 master_uri = {{ license_master_uri }}


### PR DESCRIPTION
When using a License Master, the `pass4SymmKey` must match. 
This adds that to the`server.conf` for the production build.