### PR TITLE
remove mongod.lock file before starting splunk

### DIFF
--- a/roles/docker_image_build/templates/base/entrypoint.sh
+++ b/roles/docker_image_build/templates/base/entrypoint.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+/bin/rm -f {{ splunk_home }}/var/lib/splunk/kvstore/mongo/mongod.lock
 {{ splunk_home }}/bin/splunk start --nodaemon --accept-license --answer-yes --no-prompt


### PR DESCRIPTION
When docker stops or kills a service, it does not leave time for mongod to gracefully stop, causing a stale pid in the lock file.