### PR TITLE
Added feature to upgrade KVStore to WiredTiger

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ a value of `True` when the non-standalone image is built.  Thus we have these im
 * Install user-seed.conf
 * Configure server.conf, inputs.conf with servername
 * Configure convenience indexed fields
+* Configure `storageEngineMigration` in `server.conf` when `migrate_kvstore` is defined
 
 [templates/kvstore_disable](roles/docker_image_build/templates/kvstore_disable)
 * Disables KVStore on primary builds (but overrideable)

--- a/README.md
+++ b/README.md
@@ -226,7 +226,9 @@ a value of `True` when the non-standalone image is built.  Thus we have these im
 * Install user-seed.conf
 * Configure server.conf, inputs.conf with servername
 * Configure convenience indexed fields
-* Configure `storageEngineMigration` in `server.conf` when `migrate_kvstore` is defined
+* Configure `storageEngineMigration` in `server.conf` when `migrate_kvstore` is defined (only needed on version 8.x)
+* Always upgrade kvstore from 3.6 to 4.0 (only works on 9.x)
+* Upgrade kvstore to latest version when `upgrade_kvstrore` is defined
 
 [templates/kvstore_disable](roles/docker_image_build/templates/kvstore_disable)
 * Disables KVStore on primary builds (but overrideable)

--- a/roles/docker_image_build/templates/base/entrypoint.sh
+++ b/roles/docker_image_build/templates/base/entrypoint.sh
@@ -1,2 +1,7 @@
 #!/usr/bin/env bash
+{% if migrate_kvstore is defined %}
+{{ splunk_home }}/bin/splunk start --accept-license --answer-yes --no-prompt
+{{ splunk_home }}/bin/splunk stop
+{{ splunk_home }}/bin/splunk migrate kvstore-storage-engine --target-engine wiredTiger
+{% endif %}
 {{ splunk_home }}/bin/splunk start --nodaemon --accept-license --answer-yes --no-prompt

--- a/roles/docker_image_build/templates/base/entrypoint.sh
+++ b/roles/docker_image_build/templates/base/entrypoint.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
+{{ splunk_home }}/bin/splunk migrate migrate-kvstore-36-40
 {% if migrate_kvstore is defined %}
 {{ splunk_home }}/bin/splunk start --accept-license --answer-yes --no-prompt
 {{ splunk_home }}/bin/splunk stop
 {{ splunk_home }}/bin/splunk migrate kvstore-storage-engine --target-engine wiredTiger
+{% endif %}
+{% if upgrade_kvstore is defined %}
+{{ splunk_home }}/bin/splunk migrate migrate-kvstore
 {% endif %}
 {{ splunk_home }}/bin/splunk start --nodaemon --accept-license --answer-yes --no-prompt

--- a/roles/docker_image_build/templates/base/etc/system/local/server.conf
+++ b/roles/docker_image_build/templates/base/etc/system/local/server.conf
@@ -1,0 +1,4 @@
+{% if migrate_kvstore is defined %}
+[kvstore]
+storageEngineMigration = true
+{% endif %}


### PR DESCRIPTION
Because services updates are deployed, by just creating a new image, when upgrading a service from version 8 to version 9+, the kvstore data in `var/lib/splunk/kvstore/mongo` will still on mmapv1, and will not automatically update to WiredTiger. This PR allows to upgrade the service to the WiredTiger engine by adding the `-e "migrate_kvstore=true"` to the ansible command when creating that service, and automatically upgrades mongo to version 4.0 if possible.

The `upgrade_kvstore` allows you to upgrade to the latest version of MongoDB, and will just run the standard `splunk migrate migrate-kvstore`.

Upgrading or migrating the kvstore when no upgrade or migration is needed, does not break anything, it will just say that no migration is needed.

The update/migrate process is similar to what Splunk does when upgrading splunk in place.

It is not recommended to permanently set the `migrate_kvstore` in `host_vars` or `group_vars` since this should be a one-time thing, and rather pass `-e "migrate_kvstore=true"` in the ansible command, otherwise it will do unnecessary start/stop when it is no longer needed.