### PR TITLE
Adds tini to images

### DIFF
--- a/roles/docker_image_build/defaults/main.yml
+++ b/roles/docker_image_build/defaults/main.yml
@@ -55,7 +55,8 @@ healthcheck_command: |-
   python3 {{ splunk_home }}/metrics_healthcheck.py
   {% endif %}
 
-entrypoint: "{{ splunk_home }}/entrypoint.sh"
+##entrypoint: "{{ splunk_home }}/entrypoint.sh"
+entrypoint: "This is testing for spaces"
 # by default run entrypoint as splunk user
 entrypoint_user: "{{ splunk_user_id }}:{{ splunk_group_id }}"
 

--- a/roles/docker_image_build/defaults/main.yml
+++ b/roles/docker_image_build/defaults/main.yml
@@ -6,6 +6,8 @@ ubuntu_tag: latest
 
 timezone: UTC
 
+tini_version: v0.19.0
+
 splunk_home: /opt/splunk
 splunk_user: splunk
 splunk_user_id: 8089

--- a/roles/docker_image_build/defaults/main.yml
+++ b/roles/docker_image_build/defaults/main.yml
@@ -57,6 +57,9 @@ healthcheck_command: |-
 
 ##entrypoint: "{{ splunk_home }}/entrypoint.sh"
 entrypoint: "This is testing for spaces"
+tini_entrypoint: "{{ [\"tini\", \"-g\", \"--\"] + entrypoint | split }}"
+entrypoint_list: "{{ tini_entrypoint | to_json }}"
+
 # by default run entrypoint as splunk user
 entrypoint_user: "{{ splunk_user_id }}:{{ splunk_group_id }}"
 

--- a/roles/docker_image_build/defaults/main.yml
+++ b/roles/docker_image_build/defaults/main.yml
@@ -56,7 +56,7 @@ healthcheck_command: |-
   {% endif %}
 
 entrypoint: "{{ splunk_home }}/entrypoint.sh"
-tini_entrypoint: "{{ [\"/tini\", \"-g\", \"--\", \"/bin/bash\", \"-c\"] + entrypoint | split }}"
+tini_entrypoint: "{{ [\"/tini\", \"--\", \"/bin/bash\", \"-c\"] + entrypoint | split }}"
 entrypoint_list: "{{ tini_entrypoint | to_json }}"
 
 # by default run entrypoint as splunk user

--- a/roles/docker_image_build/defaults/main.yml
+++ b/roles/docker_image_build/defaults/main.yml
@@ -55,9 +55,8 @@ healthcheck_command: |-
   python3 {{ splunk_home }}/metrics_healthcheck.py
   {% endif %}
 
-##entrypoint: "{{ splunk_home }}/entrypoint.sh"
-entrypoint: "This is testing for spaces"
-tini_entrypoint: "{{ [\"tini\", \"-g\", \"--\"] + entrypoint | split }}"
+entrypoint: "{{ splunk_home }}/entrypoint.sh"
+tini_entrypoint: "{{ [\"/tini\", \"-g\", \"--\", \"/bin/bash\", \"-c\"] + entrypoint | split }}"
 entrypoint_list: "{{ tini_entrypoint | to_json }}"
 
 # by default run entrypoint as splunk user

--- a/roles/docker_image_build/files/metricscheck/tests/logs-seen-1x/metrics.log
+++ b/roles/docker_image_build/files/metricscheck/tests/logs-seen-1x/metrics.log
@@ -1,3 +1,0 @@
-10-24-2020 00:00:00.000 +0000 INFO  Metrics - group=thruput, name=index_thruput, instantaneous_kbps=1.5817919836208267, instantaneous_eps=4.747268197433524, average_kbps=2.5931167474090575, total_k_processed=2087, kb=48.98046875, ev=147
-10-24-2020 00:00:00.000 +0000 INFO  Metrics - group=per_index_thruput, series="not_checked", kbps=3.990889931960843, eps=26.914043282402872, kb=122.6298828125, ev=827, avg_age=1.3155985489721886, max_age=8
-10-24-2020 00:00:00.000 +0000 INFO  Metrics - group=per_index_thruput, series="_internal", kbps=3.990889931960843, eps=26.914043282402872, kb=122.6298828125, ev=827, avg_age=1.3155985489721886, max_age=8

--- a/roles/docker_image_build/files/metricscheck/tests/logs-seen-2x/metrics.log
+++ b/roles/docker_image_build/files/metricscheck/tests/logs-seen-2x/metrics.log
@@ -1,4 +1,0 @@
-10-24-2020 00:00:00.000 +0000 INFO  Metrics - group=thruput, name=index_thruput, instantaneous_kbps=1.5817919836208267, instantaneous_eps=4.747268197433524, average_kbps=2.5931167474090575, total_k_processed=2087, kb=48.98046875, ev=147
-10-24-2020 00:00:00.000 +0000 INFO  Metrics - group=per_index_thruput, series="not_checked", kbps=3.990889931960843, eps=26.914043282402872, kb=122.6298828125, ev=827, avg_age=1.3155985489721886, max_age=8
-10-24-2020 00:00:00.000 +0000 INFO  Metrics - group=per_index_thruput, series="_internal", kbps=3.990889931960843, eps=26.914043282402872, kb=122.6298828125, ev=827, avg_age=1.3155985489721886, max_age=8
-10-24-2020 00:05:00.000 +0000 INFO  Metrics - group=per_index_thruput, series="_internal", kbps=0.9597524969886801, eps=6.071567569264395, kb=29.7177734375, ev=188, avg_age=0.9414893617021277, max_age=2

--- a/roles/docker_image_build/files/metricscheck/tests/logs-seen-3x/metrics.log
+++ b/roles/docker_image_build/files/metricscheck/tests/logs-seen-3x/metrics.log
@@ -1,5 +1,0 @@
-10-24-2020 00:00:00.000 +0000 INFO  Metrics - group=thruput, name=index_thruput, instantaneous_kbps=1.5817919836208267, instantaneous_eps=4.747268197433524, average_kbps=2.5931167474090575, total_k_processed=2087, kb=48.98046875, ev=147
-10-24-2020 00:00:00.000 +0000 INFO  Metrics - group=per_index_thruput, series="not_checked", kbps=3.990889931960843, eps=26.914043282402872, kb=122.6298828125, ev=827, avg_age=1.3155985489721886, max_age=8
-10-24-2020 00:00:00.000 +0000 INFO  Metrics - group=per_index_thruput, series="_internal", kbps=3.990889931960843, eps=26.914043282402872, kb=122.6298828125, ev=827, avg_age=1.3155985489721886, max_age=8
-10-24-2020 00:05:00.000 +0000 INFO  Metrics - group=per_index_thruput, series="_internal", kbps=0.9597524969886801, eps=6.071567569264395, kb=29.7177734375, ev=188, avg_age=0.9414893617021277, max_age=2
-10-24-2020 00:10:00.000 +0000 INFO  Metrics - group=per_index_thruput, series="_internal", kbps=0.8307405471339425, eps=5.491373246443012, kb=25.7177734375, ev=170, avg_age=0.888235294117647, max_age=1

--- a/roles/docker_image_build/files/metricscheck/tests/logs-test-iterators/metrics.log
+++ b/roles/docker_image_build/files/metricscheck/tests/logs-test-iterators/metrics.log
@@ -1,2 +1,0 @@
-metrics.log line 1
-metrics.log line 2

--- a/roles/docker_image_build/templates/base/entrypoint.sh
+++ b/roles/docker_image_build/templates/base/entrypoint.sh
@@ -1,11 +1,54 @@
 #!/usr/bin/env bash
-{{ splunk_home }}/bin/splunk migrate migrate-kvstore-36-40
-{% if migrate_kvstore is defined %}
-{{ splunk_home }}/bin/splunk start --accept-license --answer-yes --no-prompt
-{{ splunk_home }}/bin/splunk stop
-{{ splunk_home }}/bin/splunk migrate kvstore-storage-engine --target-engine wiredTiger
-{% endif %}
-{% if upgrade_kvstore is defined %}
-{{ splunk_home }}/bin/splunk migrate migrate-kvstore
-{% endif %}
-{{ splunk_home }}/bin/splunk start --nodaemon --accept-license --answer-yes --no-prompt
+
+set -e
+
+# performs mongod upgrades and engine migrations as configured
+migrate_kvstore() {
+    {{ splunk_home }}/bin/splunk migrate migrate-kvstore-36-40
+
+    {% if migrate_kvstore is defined %}
+    {{ splunk_home }}/bin/splunk start --accept-license --answer-yes --no-prompt $@
+    {{ splunk_home }}/bin/splunk stop
+    {{ splunk_home }}/bin/splunk migrate kvstore-storage-engine --target-engine wiredTiger
+    {% endif %}
+
+    {% if upgrade_kvstore is defined %}
+    {{ splunk_home }}/bin/splunk migrate migrate-kvstore
+    {% endif %}
+}
+
+# starts Splunk using the CLI
+start_splunk() {
+    exec {{ splunk_home }}/bin/splunk start --nodaemon --accept-license --answer-yes --no-prompt $@
+}
+
+# stops Splunk using the CLI
+stop_splunk() {
+    exec {{ splunk_home }}/bin/splunk stop $@ 2>/dev/null || true
+}
+
+# calls stop when SIGINT and SIGTERM are received for graceful shutdowns in Docker Swarm
+trap stop SIGINT SIGTERM
+
+# restarts Splunk using the CLI
+restart_splunk() {
+    exec {{ splunk_home }}/bin/splunk restart $@ 2>/dev/null || true
+}
+
+# BEGIN EXECUTION HERE
+
+case "${1}" in
+    "migrate_kvstore")
+        migrate_kvstore
+    ;;
+    "start_splunk"|"")
+        migrate_kvstore
+        start
+    ;;
+    "stop_splunk")
+        stop
+    ;;
+    "restart_splunk")
+        restart
+    ;;
+esac

--- a/roles/docker_image_build/templates/base/entrypoint.sh
+++ b/roles/docker_image_build/templates/base/entrypoint.sh
@@ -23,6 +23,7 @@ start_splunk() {
     # note: this "fixes" signal forwarding so that the trap for stop_splunk
     #       should not be needed, however it has been included here in case it
     #       occurs before the exec is complete
+    migrate_kvstore
     exec {{ splunk_home }}/bin/splunk start --nodaemon --accept-license --answer-yes --no-prompt $@
 }
 

--- a/roles/docker_image_build/templates/base/entrypoint.sh
+++ b/roles/docker_image_build/templates/base/entrypoint.sh
@@ -28,7 +28,7 @@ stop_splunk() {
 }
 
 # calls stop when SIGINT and SIGTERM are received for graceful shutdowns in Docker Swarm
-trap stop SIGINT SIGTERM
+trap stop_splunk SIGINT SIGTERM
 
 # restarts Splunk using the CLI
 restart_splunk() {

--- a/roles/docker_image_build/templates/base/entrypoint.sh
+++ b/roles/docker_image_build/templates/base/entrypoint.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
+# shellcheck disable=all
 
-set -e
+# set -e
 
 # performs mongod upgrades and engine migrations as configured
 migrate_kvstore() {
-    {{ splunk_home }}/bin/splunk migrate migrate-kvstore-36-40 || true
+    {{ splunk_home }}/bin/splunk migrate migrate-kvstore-36-40
 
     {% if migrate_kvstore is defined %}
     {{ splunk_home }}/bin/splunk start --accept-license --answer-yes --no-prompt $@
@@ -19,22 +20,45 @@ migrate_kvstore() {
 
 # starts Splunk using the CLI
 start_splunk() {
-    # replace the process running this script with the process running Splunk
-    # note: this "fixes" signal forwarding so that the trap for stop_splunk
-    #       should not be needed, however it has been included here in case it
-    #       occurs before the exec is complete
+    printf "Performing kvstore migration before starting Splunk\n"
     migrate_kvstore
-    exec {{ splunk_home }}/bin/splunk start --nodaemon --accept-license --answer-yes --no-prompt $@
+
+    printf "Starting Splunk with arguments ${*}\n"
+    {{ splunk_home }}/bin/splunk start --nodaemon --accept-license --answer-yes --no-prompt $@ &
+    splunk_pid=$!
+    printf "Splunk is now running with pid ${splunk_pid}\n"
+    wait_for_splunk_to_stop
 }
 
 # stops Splunk using the CLI
 stop_splunk() {
-    {{ splunk_home }}/bin/splunk stop $@ 2>/dev/null || true
+    printf "Stopping Splunk running with pid ${splunk_pid} for graceful shutdown\n"
+    {{ splunk_home }}/bin/splunk stop
+    if [ -f {{ splunk_home }}/var/run/splunk/conf-mutator.pid ]; then
+        printf "Found conf-mutator.pid file containing pid %d after shutdown, removing...\n" "$(cat {{ splunk_home }}/var/run/splunk/conf-mutator.pid)"
+        rm -vf {{ splunk_home }}/var/run/splunk/conf-mutator.pid
+    fi
+}
+
+wait_for_splunk_to_stop() {
+    wait -n ${splunk_pid}
+    printf "Entrypoint has detected that Splunk is no longer running and is now exiting\n"
+}
+
+# log graceful shutdown and call stop_splunk
+graceful_shutdown() {
+    printf "Received SIGTERM interrupt, now stopping Splunk running with PID ${splunk_pid} for graceful shutdown\n"
+    printf "Stopping Splunk running with pid ${splunk_pid} for graceful shutdown\n"
+    {{ splunk_home }}/bin/splunk stop
+    if [ -f {{ splunk_home }}/var/run/splunk/conf-mutator.pid ]; then
+        printf "Found conf-mutator.pid file containing pid %d after shutdown, removing...\n" "$(cat {{ splunk_home }}/var/run/splunk/conf-mutator.pid)"
+        rm -vf {{ splunk_home }}/var/run/splunk/conf-mutator.pid
+    fi
 }
 
 # calls stop_splunk function when SIGINT and SIGTERM are received
 # to allow for graceful shutdowns in Docker Swarm
-trap stop_splunk SIGINT SIGTERM
+trap graceful_shutdown SIGTERM
 
 # restarts Splunk using the CLI
 restart_splunk() {

--- a/roles/docker_image_build/templates/base/entrypoint.sh
+++ b/roles/docker_image_build/templates/base/entrypoint.sh
@@ -41,14 +41,14 @@ case "${1}" in
     "migrate_kvstore")
         migrate_kvstore
     ;;
-    "start_splunk"|"")
+    "start"|"")
         migrate_kvstore
-        start
+        start_splunk
     ;;
-    "stop_splunk")
-        stop
+    "stop")
+        stop_splunk
     ;;
-    "restart_splunk")
-        restart
+    "restart")
+        restart_splunk
     ;;
 esac

--- a/roles/docker_image_build/templates/base/entrypoint.sh
+++ b/roles/docker_image_build/templates/base/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 # performs mongod upgrades and engine migrations as configured
 migrate_kvstore() {
-    {{ splunk_home }}/bin/splunk migrate migrate-kvstore-36-40
+    {{ splunk_home }}/bin/splunk migrate migrate-kvstore-36-40 || true
 
     {% if migrate_kvstore is defined %}
     {{ splunk_home }}/bin/splunk start --accept-license --answer-yes --no-prompt $@

--- a/roles/docker_image_build/templates/base/entrypoint.sh
+++ b/roles/docker_image_build/templates/base/entrypoint.sh
@@ -19,29 +19,37 @@ migrate_kvstore() {
 
 # starts Splunk using the CLI
 start_splunk() {
+    # replace the process running this script with the process running Splunk
+    # note: this "fixes" signal forwarding so that the trap for stop_splunk
+    #       should not be needed, however it has been included here in case it
+    #       occurs before the exec is complete
     exec {{ splunk_home }}/bin/splunk start --nodaemon --accept-license --answer-yes --no-prompt $@
 }
 
 # stops Splunk using the CLI
 stop_splunk() {
-    exec {{ splunk_home }}/bin/splunk stop $@ 2>/dev/null || true
+    {{ splunk_home }}/bin/splunk stop $@ 2>/dev/null || true
 }
 
-# calls stop when SIGINT and SIGTERM are received for graceful shutdowns in Docker Swarm
+# calls stop_splunk function when SIGINT and SIGTERM are received
+# to allow for graceful shutdowns in Docker Swarm
 trap stop_splunk SIGINT SIGTERM
 
 # restarts Splunk using the CLI
 restart_splunk() {
-    exec {{ splunk_home }}/bin/splunk restart $@ 2>/dev/null || true
+    stop_splunk
+    start_splunk
 }
 
-# BEGIN EXECUTION HERE
+########################
+# BEGIN EXECUTION HERE #
+########################
 
 case "${1}" in
     "migrate_kvstore")
         migrate_kvstore
     ;;
-    "start"|"")
+    "start"|"") # default
         migrate_kvstore
         start_splunk
     ;;

--- a/roles/docker_image_build/templates/build/Dockerfile
+++ b/roles/docker_image_build/templates/build/Dockerfile
@@ -71,7 +71,7 @@ RUN {{ splunk_home }}/bin/splunk btool check
 {% endif %}
 
 # entrypoint.sh may do run-time configurations prior to starting splunk
-ENTRYPOINT [ "/tini", "-g", "--", "{{ entrypoint | replace(' ','", ")}}" ]
+ENTRYPOINT [ "/tini", "-g", "--", "{{ entrypoint | replace(' ',", ")}}" ]
 
 {% if healthcheck_command %}
 HEALTHCHECK \

--- a/roles/docker_image_build/templates/build/Dockerfile
+++ b/roles/docker_image_build/templates/build/Dockerfile
@@ -71,7 +71,7 @@ RUN {{ splunk_home }}/bin/splunk btool check
 {% endif %}
 
 # entrypoint.sh may do run-time configurations prior to starting splunk
-ENTRYPOINT [ "/tini", "-g", "--", "{{ entrypoint | replace(' ','", ")}}" ]
+ENTRYPOINT "{{ [ "/tini", "-g", "--", entrypoint | split ] | flatten }}"
 
 {% if healthcheck_command %}
 HEALTHCHECK \

--- a/roles/docker_image_build/templates/build/Dockerfile
+++ b/roles/docker_image_build/templates/build/Dockerfile
@@ -71,7 +71,7 @@ RUN {{ splunk_home }}/bin/splunk btool check
 {% endif %}
 
 # entrypoint.sh may do run-time configurations prior to starting splunk
-ENTRYPOINT [ "/tini", "-g", "--", {{ entrypoint | tojson | join(', ') }} ]
+ENTRYPOINT [ "/tini", "-g", "--", "{{ entrypoint | replace(' ','", ")}}" ]
 
 {% if healthcheck_command %}
 HEALTHCHECK \

--- a/roles/docker_image_build/templates/build/Dockerfile
+++ b/roles/docker_image_build/templates/build/Dockerfile
@@ -71,7 +71,7 @@ RUN {{ splunk_home }}/bin/splunk btool check
 {% endif %}
 
 # entrypoint.sh may do run-time configurations prior to starting splunk
-ENTRYPOINT "{{ [ "/tini", "-g", "--", entrypoint | split ] | flatten }}"
+ENTRYPOINT [ "/tini", "-g", "--", "A", "command", "with", "spaces", "in", "it" ]
 
 {% if healthcheck_command %}
 HEALTHCHECK \

--- a/roles/docker_image_build/templates/build/Dockerfile
+++ b/roles/docker_image_build/templates/build/Dockerfile
@@ -14,8 +14,8 @@ RUN ln -fs /usr/share/zoneinfo/{{ timezone }} /etc/localtime \
   && apt-get clean
 
 # Add tini as an init to fix signal forwarding when using a bash script as the entrypoint
-ENV TINI_VERSION {{ tini_version }}
-ADD https://github.com/krallin/tini/releases/download/${{ tini_version }}/tini /tini
+ENV TINI_VERSION "{{ tini_version }}"
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
 {% if install_splunk %}

--- a/roles/docker_image_build/templates/build/Dockerfile
+++ b/roles/docker_image_build/templates/build/Dockerfile
@@ -71,7 +71,7 @@ RUN {{ splunk_home }}/bin/splunk btool check
 {% endif %}
 
 # entrypoint.sh may do run-time configurations prior to starting splunk
-ENTRYPOINT [ "/tini", "-g", "--", "A", "command", "with", "spaces", "in", "it" ]
+ENTRYPOINT "{{ [ "/tini", "-g", "--", entrypoint | split ] | flatten }}"
 
 {% if healthcheck_command %}
 HEALTHCHECK \

--- a/roles/docker_image_build/templates/build/Dockerfile
+++ b/roles/docker_image_build/templates/build/Dockerfile
@@ -71,7 +71,7 @@ RUN {{ splunk_home }}/bin/splunk btool check
 {% endif %}
 
 # entrypoint.sh may do run-time configurations prior to starting splunk
-ENTRYPOINT "{{ [ "/tini", "-g", "--", entrypoint | split ] | flatten }}"
+ENTRYPOINT [ "/tini", "-g", "--", "{{ entrypoint | replace(' ','", ")}}" ]
 
 {% if healthcheck_command %}
 HEALTHCHECK \

--- a/roles/docker_image_build/templates/build/Dockerfile
+++ b/roles/docker_image_build/templates/build/Dockerfile
@@ -13,6 +13,11 @@ RUN ln -fs /usr/share/zoneinfo/{{ timezone }} /etc/localtime \
   && apt-get install -y --no-install-recommends wget ca-certificates {{ apt_packages|join(' ') }} \
   && apt-get clean
 
+# Add tini as an init to fix signal forwarding when using a bash script as the entrypoint
+ENV TINI_VERSION {{ tini_version }}
+ADD https://github.com/krallin/tini/releases/download/${{ tini_version }}/tini /tini
+RUN chmod +x /tini
+
 {% if install_splunk %}
 # change user prior to untarring splunk
 USER {{ splunk_user_id }}:{{ splunk_group_id }}
@@ -40,7 +45,7 @@ COPY {% if 'owner' in copy_path_config %}--chown={{ copy_path_config.owner }}{% 
 {% endfor %}
 
 {% if run_commands %}
-# configurable RUN commands are called after file copies so they can use the copied fils
+# configurable RUN commands are called after file copies so they can use the copied files
 {% for run_command in run_commands %}
 {% if 'user' in run_command %}
 USER {{ run_command.user }}{% if 'group' in run_command  %}:{{ run_command.group }}{% endif %}
@@ -66,7 +71,7 @@ RUN {{ splunk_home }}/bin/splunk btool check
 {% endif %}
 
 # entrypoint.sh may do run-time configurations prior to starting splunk
-ENTRYPOINT {{ entrypoint }}
+ENTRYPOINT [ "/tini", "--", {{ entrypoint | tojson | join(', ') }} ]
 
 {% if healthcheck_command %}
 HEALTHCHECK \

--- a/roles/docker_image_build/templates/build/Dockerfile
+++ b/roles/docker_image_build/templates/build/Dockerfile
@@ -71,7 +71,7 @@ RUN {{ splunk_home }}/bin/splunk btool check
 {% endif %}
 
 # entrypoint.sh may do run-time configurations prior to starting splunk
-ENTRYPOINT [ "/tini", "--", {{ entrypoint | tojson | join(', ') }} ]
+ENTRYPOINT [ "/tini", "-g", "--", {{ entrypoint | tojson | join(', ') }} ]
 
 {% if healthcheck_command %}
 HEALTHCHECK \

--- a/roles/docker_image_build/templates/build/Dockerfile
+++ b/roles/docker_image_build/templates/build/Dockerfile
@@ -71,7 +71,7 @@ RUN {{ splunk_home }}/bin/splunk btool check
 {% endif %}
 
 # entrypoint.sh may do run-time configurations prior to starting splunk
-ENTRYPOINT [ "/tini", "-g", "--", "{{ entrypoint | replace(' ',", ")}}" ]
+ENTRYPOINT {{ entrypoint_list }}
 
 {% if healthcheck_command %}
 HEALTHCHECK \

--- a/roles/docker_service_deploy/defaults/main.yml
+++ b/roles/docker_service_deploy/defaults/main.yml
@@ -11,3 +11,7 @@ splunk_user: splunk
 splunk_user_id: 8089
 splunk_group: splunk
 splunk_group_id: 8089
+
+# https://docs.docker.com/reference/cli/docker/service/create/
+# Note: Docker Swarm defaults to 10s
+stop_grace_period: 10s

--- a/roles/docker_service_deploy/tasks/create_service.yml
+++ b/roles/docker_service_deploy/tasks/create_service.yml
@@ -20,6 +20,7 @@
       driver: "{{ log_driver | default(omit) }}"
       options: "{{ log_driver_options | default(omit) }}"
     env: "{{ env | default(omit) }}"
+    stop_grace_period: "{{ stop_grace_period | default(omit) }}"
   become: "{{ docker_become_user is defined }}"
   become_user: "{{ docker_become_user|default(omit) }}"
   # tagged to allow skipping to allow only management of volumes


### PR DESCRIPTION
Adds tini to images as an init for proper signal forwarding/handling so that Splunk is stopped gracefully during service restarts. The tini version can be set via the tini_version ansible variable and defaults to a value of `v0.19.0`