### PR TITLE
Added task to pull images to all nodes

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -61,3 +61,5 @@ role_build_variants:
 
 # skip_build_and_push is overrideable by using the skip-if-in-registry tag, but defaults to false to always perform the build
 skip_build_and_push: false
+# Pull images on all docker hosts when running deploy.yml. Required for ECR authentication.
+pull_images: false

--- a/roles/docker_service_deploy/tasks/main.yml
+++ b/roles/docker_service_deploy/tasks/main.yml
@@ -15,6 +15,10 @@
     loop_var: volume_item
   tags: volumes
 
+- name: Pull images
+  include_tasks: pull_images.yml
+  when: pull_images == true
+
 - name: handle config changes
   block:
     # docker configs can't be changed while associated with a running service
@@ -26,7 +30,7 @@
       include_tasks: create_service.yml
 
   rescue:
-    - name:  create temporary configs
+    - name: create temporary configs
       include_tasks: create_configs.yml
       vars:
         intermediate_configs: true
@@ -36,7 +40,7 @@
       vars:
         intermediate_configs: true
 
-    - name:  update final configs
+    - name: update final configs
       include_tasks: create_configs.yml
 
     - name: update service with final configs

--- a/roles/docker_service_deploy/tasks/pull_images.yml
+++ b/roles/docker_service_deploy/tasks/pull_images.yml
@@ -1,5 +1,5 @@
 ---
-- name: pull iamges on all hosts
+- name: pull images on all hosts
   docker_image:
     #name: "{{ repository }}:443/{{ docker_image_name }}:{{ version }}"
     name: "{{ repository_deploy_image }}"

--- a/roles/docker_service_deploy/tasks/pull_images.yml
+++ b/roles/docker_service_deploy/tasks/pull_images.yml
@@ -1,0 +1,11 @@
+---
+- name: pull iamges on all hosts
+  docker_image:
+    #name: "{{ repository }}:443/{{ docker_image_name }}:{{ version }}"
+    name: "{{ repository_deploy_image }}"
+    source: pull
+  loop: "{{ groups['docker_swarm_managers'] }}"
+  delegate_to: "{{ item }}"
+  become: "{{ docker_become_user is defined }}"
+  become_user: "{{ docker_become_user|default(omit) }}"
+


### PR DESCRIPTION
When using shot-lived credentials to a docker registry, only the node that the service was first deployed to will have that image, causing the image to fail when starting on a different node.

This will pull the image to all docker nodes while the login credentials are still valid.